### PR TITLE
Strict choicers

### DIFF
--- a/api/api/api.api
+++ b/api/api/api.api
@@ -608,12 +608,14 @@ public final class me/func/mod/selection/Choicer : me/func/mod/selection/Storage
 	public fun add (Lme/func/mod/selection/Button;)V
 	public fun buttons ([Lme/func/mod/selection/Button;)V
 	public fun clear ()V
+	public final fun getAllowClosing ()Z
 	public final fun getDescription ()Ljava/lang/String;
 	public fun getStorage ()Ljava/util/List;
 	public fun getTitle ()Ljava/lang/String;
 	public fun getUuid ()Ljava/util/UUID;
 	public synthetic fun open (Lorg/bukkit/entity/Player;)Lme/func/mod/selection/Openable;
 	public fun open (Lorg/bukkit/entity/Player;)Lme/func/mod/selection/Storage;
+	public final fun setAllowClosing (Z)V
 	public final fun setDescription (Ljava/lang/String;)V
 	public fun setStorage (Ljava/util/List;)V
 	public fun setTitle (Ljava/lang/String;)V

--- a/api/src/main/kotlin/me/func/mod/selection/Choicer.kt
+++ b/api/src/main/kotlin/me/func/mod/selection/Choicer.kt
@@ -10,8 +10,13 @@ class Choicer(
     var description: String = "Выбери нужный под-режим!",
     override var storage: MutableList<Button> = mutableListOf()
 ) : Storage {
+    var allowClosing: Boolean = true
+
     constructor(title: String, description: String, vararg storage: Button) :
             this(UUID.randomUUID(), title, description, storage.toMutableList())
 
-    override fun open(player: Player): Storage = open(player, "storage:choice") { string(description) }
+    override fun open(player: Player): Storage = open(player, "storage:choice") {
+        string(description)
+        boolean(allowClosing)
+    }
 }

--- a/mod/src/main/kotlin/experimental/Experimental.kt
+++ b/mod/src/main/kotlin/experimental/Experimental.kt
@@ -156,6 +156,7 @@ class Experimental {
                         UUID.fromString(NetUtil.readUtf8(this)),
                         NetUtil.readUtf8(this).replace("&", "§"), // title
                         NetUtil.readUtf8(this).replace("&", "§"), // description
+                        readBoolean(), // allow closing this menu
                         readIcons(this)
                     )
                 )

--- a/mod/src/main/kotlin/experimental/storage/PlayChoice.kt
+++ b/mod/src/main/kotlin/experimental/storage/PlayChoice.kt
@@ -28,9 +28,14 @@ class PlayChoice(
     override var uuid: UUID,
     override var title: String,
     @JvmField var description: String,
+    allowClosing: Boolean,
     override var storage: MutableList<StorageNode<*>>
 ) : Storable(uuid, title, storage) {
     init {
+        if (!allowClosing) {
+            keyTypedHandlers.removeFirstOrNull() // удаление листенера ESC перед регистрацией наших листенеров
+        }
+
         val padding = 8.0
         val scaling = 0.85
         val buttonSize = V3(100.0, 145.0, 1.0)
@@ -126,36 +131,38 @@ class PlayChoice(
             }
         }
 
-        val backButtonSize = 20.0
-        +carved {
-            carveSize = 1.0
-            align = CENTER
-            origin = CENTER
-            offset.y = buttonSize.y * scaling
-            size = V3(76.0, backButtonSize)
-            val normalColor = Color(160, 29, 40, 0.83)
-            val hoveredColor = Color(231, 61, 75, 0.83)
-            color = normalColor
-            onHover {
-                animate(0.08, Easings.QUINT_OUT) {
-                    color = if (hovered) hoveredColor else normalColor
-                    scale = V3(if (hovered) 1.1 else 1.0, if (hovered) 1.1 else 1.0, 1.0)
-                }
-            }
-            onMouseUp {
-                close()
-                menuStack.clear()
-            }
-            +text {
+        if (allowClosing) {
+            val backButtonSize = 20.0
+            +carved {
+                carveSize = 1.0
                 align = CENTER
                 origin = CENTER
-                color = WHITE
-                scale = V3(0.9, 0.9, 0.9)
-                content = "Выйти [ ESC ]"
-                shadow = true
+                offset.y = buttonSize.y * scaling
+                size = V3(76.0, backButtonSize)
+                val normalColor = Color(160, 29, 40, 0.83)
+                val hoveredColor = Color(231, 61, 75, 0.83)
+                color = normalColor
+                onHover {
+                    animate(0.08, Easings.QUINT_OUT) {
+                        color = if (hovered) hoveredColor else normalColor
+                        scale = V3(if (hovered) 1.1 else 1.0, if (hovered) 1.1 else 1.0, 1.0)
+                    }
+                }
+                onMouseUp {
+                    close()
+                    menuStack.clear()
+                }
+                +text {
+                    align = CENTER
+                    origin = CENTER
+                    color = WHITE
+                    scale = V3(0.9, 0.9, 0.9)
+                    content = "Выйти [ ESC ]"
+                    shadow = true
+                }
             }
+            onKeyTyped { _, code -> if (code == Keyboard.KEY_ESCAPE) menuStack.clear() }
         }
-        onKeyTyped { _, code -> if (code == Keyboard.KEY_ESCAPE) menuStack.clear() }
         +hoverContainer
     }
 }


### PR DESCRIPTION
Allow specifying that Choicer cannot be closed by player (only by server)
CSC use-case: player should select class before he can start playing